### PR TITLE
Add ruff pre-commit and clean unused imports

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.4.5
+    hooks:
+      - id: ruff
+        args: [--fix, --select=F401]

--- a/app/api/__init__.py
+++ b/app/api/__init__.py
@@ -1,7 +1,3 @@
-"""
-API module initialization.
-"""
-
-from flask import Blueprint
+"""API module initialization."""
 
 # This module contains the API blueprints and related functionality

--- a/app/api/v1/__init__.py
+++ b/app/api/v1/__init__.py
@@ -2,7 +2,7 @@
 API v1 blueprint registration and initialization.
 """
 
-from flask import Blueprint
+from flask import Blueprint, redirect, request
 from app.api.v1.tasks import tasks_bp
 from app.api.v1.agents import agents_bp
 from app.api.v1.executions import executions_bp
@@ -79,7 +79,6 @@ def api_info():
 legacy_api = Blueprint('legacy_api', __name__, url_prefix='/api')
 
 # Create compatibility routes for legacy API paths
-from flask import redirect, request
 
 # Redirect /api/agents to /api/v1/agents
 @legacy_api.route('/agents', defaults={'path': ''}, methods=['GET', 'POST', 'PUT', 'DELETE', 'PATCH'])

--- a/app/api/v1/tasks.py
+++ b/app/api/v1/tasks.py
@@ -8,8 +8,7 @@ from app.services.task_service import TaskService
 from app.services.agent_service import AgentService
 from app.schemas import (
     TaskCreate, TaskUpdate, TaskStatusUpdate,
-    task_to_response, tasks_to_list_response,
-    TaskAssignmentSchema
+    task_to_response, TaskAssignmentSchema
 )
 from app.core.exceptions import TaskNotFoundError, AgentNotFoundError, AgentNotActiveError
 from app.core.constants import TaskStatus

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -1,7 +1,6 @@
 """
 Centralized configuration management with environment-specific settings
 """
-import os
 from typing import Optional, Dict, Any
 from pydantic import Field, validator
 from pydantic_settings import BaseSettings

--- a/app/models/agent.py
+++ b/app/models/agent.py
@@ -1,13 +1,17 @@
 """
 Agent model with enhanced functionality
 """
+from __future__ import annotations
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any, List
+from typing import Optional, Dict, Any, List, TYPE_CHECKING
 from sqlalchemy import Column, Integer, String, Text, DateTime, Boolean, JSON
 from sqlalchemy.orm import relationship
 
 from db import db
 from app.core.constants import LLMProvider
+
+if TYPE_CHECKING:
+    from app.models.execution import AgentExecution
 
 
 def utcnow():

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -1,13 +1,17 @@
 """
 Task model with enhanced functionality
 """
+from __future__ import annotations
 from datetime import datetime, timezone
-from typing import Optional, Dict, Any
-from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey, JSON
+from typing import Optional, Dict, Any, TYPE_CHECKING
+from sqlalchemy import Column, Integer, String, Text, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
 
 from db import db
 from app.core.constants import TaskStatus, ExecutionStatus
+
+if TYPE_CHECKING:
+    from app.models.execution import AgentExecution
 
 
 def utcnow():

--- a/app/repositories/agent_repository.py
+++ b/app/repositories/agent_repository.py
@@ -2,7 +2,7 @@
 Agent repository implementation
 """
 from typing import List, Optional, Dict, Any
-from sqlalchemy import desc, asc
+from sqlalchemy import desc
 
 from app.repositories.base import BaseRepository, PaginatedResult, paginate_query
 from app.models.agent import Agent

--- a/app/repositories/base.py
+++ b/app/repositories/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from typing import TypeVar, Generic, List, Optional, Dict, Any
 from sqlalchemy.orm import Session
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy import and_, or_, desc, asc
+from sqlalchemy import desc, asc
 
 from app.core.exceptions import DatabaseError, NotFoundError
 from app.core.logging import get_logger, log_database_operation

--- a/app/repositories/execution_repository.py
+++ b/app/repositories/execution_repository.py
@@ -3,7 +3,7 @@ Execution repository implementation
 """
 from typing import List, Optional, Dict, Any
 from datetime import datetime, timedelta
-from sqlalchemy import desc, asc, func
+from sqlalchemy import desc
 
 from app.repositories.base import BaseRepository, PaginatedResult, paginate_query
 from app.models.execution import AgentExecution

--- a/app/repositories/task_repository.py
+++ b/app/repositories/task_repository.py
@@ -2,7 +2,7 @@
 Task repository implementation
 """
 from typing import List, Optional, Dict, Any
-from sqlalchemy import desc, asc
+from sqlalchemy import desc
 
 from app.repositories.base import BaseRepository, PaginatedResult, paginate_query
 from app.models.task import Task

--- a/app/services/agent_service.py
+++ b/app/services/agent_service.py
@@ -2,11 +2,10 @@
 Agent service layer for business logic
 """
 from typing import List, Optional, Dict, Any
-from datetime import datetime
 
 from app.repositories.agent_repository import AgentRepository
 from app.models.agent import Agent
-from app.core.constants import LLMProvider, API_MESSAGES, ERROR_MESSAGES
+from app.core.constants import LLMProvider
 from app.core.exceptions import (
     AgentNotFoundError, AgentValidationError, AgentNotActiveError,
     ValidationError, ConflictError

--- a/app/services/execution_service.py
+++ b/app/services/execution_service.py
@@ -2,7 +2,6 @@
 Execution service layer for business logic
 """
 from typing import List, Optional, Dict, Any
-from datetime import datetime, timedelta
 
 from app.repositories.execution_repository import ExecutionRepository
 from app.models.execution import AgentExecution

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -2,16 +2,15 @@
 Task service layer for business logic
 """
 from typing import List, Optional, Dict, Any
-from datetime import datetime
 
 from app.repositories.task_repository import TaskRepository
 from app.models.task import Task
-from app.core.constants import TaskStatus, ExecutionStatus, API_MESSAGES, ERROR_MESSAGES
+from app.core.constants import TaskStatus, ExecutionStatus, ERROR_MESSAGES
 from app.core.exceptions import (
     TaskNotFoundError, TaskValidationError, TaskStatusError,
-    ValidationError, ConflictError
+    ConflictError
 )
-from app.core.logging import get_logger, log_database_operation
+from app.core.logging import get_logger
 
 logger = get_logger(__name__)
 

--- a/celery_app.py
+++ b/celery_app.py
@@ -52,7 +52,6 @@ def create_app_context():
     
     # Import the existing db instance and models
     from db import db
-    from app.models import Task, Agent, AgentExecution
     
     # Create a minimal Flask app for Celery tasks
     app = Flask(__name__)

--- a/llm_providers.py
+++ b/llm_providers.py
@@ -42,7 +42,6 @@ class OpenAIProvider(LLMProvider):
     
     def __init__(self, api_key: str = None, model: str = "gpt-4"):
         try:
-            import openai
             from openai import OpenAI
         except ImportError:
             raise ImportError("openai package is required for OpenAI provider")
@@ -228,7 +227,7 @@ class GeminiProvider(LLMProvider):
                     desc = func.get('description', 'No description')
                     tool_descriptions.append(f"- {name}: {desc}")
                 
-                formatted_content += f"\nAvailable tools:\n" + "\n".join(tool_descriptions)
+                formatted_content += "\nAvailable tools:\n" + "\n".join(tool_descriptions)
                 formatted_content += "\n\nIf you need to use a tool, respond with: TOOL_CALL: tool_name(arguments)"
             
             # Make API call

--- a/main.py
+++ b/main.py
@@ -2,9 +2,12 @@ from flask import Flask, render_template, request, redirect, url_for, flash
 from flask_migrate import Migrate
 from datetime import datetime
 import os
+import sys
 import logging
 from dotenv import load_dotenv
 from db import db
+from app.models import Task
+from app.api.v1 import register_blueprints
 
 # Load environment variables from .env file
 load_dotenv()
@@ -21,15 +24,8 @@ logger = logging.getLogger(__name__)
 db.init_app(app)
 migrate = Migrate(app, db)
 
-from app.models import Task, Agent, AgentExecution
-from celery_app import execute_agent_task_async
-
-# Register API blueprints
-import sys
-import os
 sys.path.append(os.path.dirname(os.path.abspath(__file__)))
 
-from app.api.v1 import register_blueprints
 register_blueprints(app)
 
 # Routes

--- a/manage_migrations.py
+++ b/manage_migrations.py
@@ -5,12 +5,10 @@ Provides additional migration utilities beyond Flask-Migrate
 """
 import os
 import sys
-import json
 import subprocess
 from datetime import datetime
 from flask import Flask
 from flask_migrate import Migrate, upgrade, downgrade, current, history, init, migrate as create_migration
-from sqlalchemy import text
 from db import db
 from app.models import Task, Agent, AgentExecution
 


### PR DESCRIPTION
## Summary
- configure pre-commit with ruff to auto-remove unused imports
- clean up unused imports across the codebase
- fix forward references with TYPE_CHECKING
- tidy `main.py` and API blueprint imports

## Testing
- `pytest -q`
- `ruff check . --select F401`
- `pre-commit run --files app/api/__init__.py llm_providers.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686abd1e90108320a95ce1dd150f7440