### PR TITLE
Add .env.example with placeholders

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,23 @@
+# Database
+DATABASE_URL=postgresql://kanban_user:kanban_pass@localhost:5432/kanban_db
+
+# Flask
+SECRET_KEY=your-secret-key-change-in-production
+
+# Redis (for background tasks)
+REDIS_URL=redis://localhost:6379/0
+
+# LLM Provider API Keys (at least one required for AI features)
+OPENAI_API_KEY=your-openai-api-key-here
+ANTHROPIC_API_KEY=your-anthropic-api-key-here
+GEMINI_API_KEY=your-gemini-api-key-here
+
+# Email Tool Configuration (optional)
+SMTP_SERVER=smtp.gmail.com
+SMTP_PORT=587
+SMTP_USERNAME=your-email@gmail.com
+SMTP_PASSWORD=your-app-password
+
+# Web Search Tool Configuration (optional)
+GOOGLE_SEARCH_API_KEY=your-google-search-api-key
+GOOGLE_SEARCH_ENGINE_ID=your-search-engine-id

--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,8 @@ docker-compose.override.yml
 # Environment
 .env
 .env.*
+# Allow an example env file for reference
+!.env.example
 .venv/
 
 # Pytest


### PR DESCRIPTION
## Summary
- provide `.env.example` for database, Redis, secret key, provider API keys and optional SMTP/Google Search
- adjust `.gitignore` so `.env.example` is tracked

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686abe29235c83208af429031ff6a363