### PR TITLE
Add CI testing and Cloud Run deployment workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Deploy to Cloud Run
+
+on:
+  push:
+    tags:
+      - 'deploy-*'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT }}
+          service_account_key: ${{ secrets.GCP_SA_KEY }}
+          export_default_credentials: true
+
+      - name: Build and push container
+        run: |
+          gcloud builds submit --tag gcr.io/${{ secrets.GCP_PROJECT }}/taskter:${{ github.sha }} .
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: taskter
+          region: ${{ secrets.GCP_REGION }}
+          image: gcr.io/${{ secrets.GCP_PROJECT }}/taskter:${{ github.sha }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
+          pip install pytest
       - name: Run tests
         run: |
           pytest -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Test
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          pytest -v

--- a/README.md
+++ b/README.md
@@ -568,6 +568,29 @@ curl http://localhost:5001/api/v1/executions
 4. Test thoroughly
 5. Submit a pull request
 
+## Continuous Integration
+
+All pull requests automatically run the test suite via GitHub Actions. The
+workflow defined in `.github/workflows/test.yml` installs dependencies from
+`requirements.txt` and executes `pytest`.
+
+## Preview Deployments
+
+To manually test a feature branch in Google Cloud Run, push a tag beginning with
+`deploy-` to the branch:
+
+```bash
+git tag deploy-my-feature
+git push origin deploy-my-feature
+```
+
+The `deploy.yml` workflow builds a container image and deploys it to Cloud Run.
+Configure the following repository secrets for authentication:
+
+- `GCP_PROJECT` – your Google Cloud project ID
+- `GCP_REGION` – the Cloud Run region
+- `GCP_SA_KEY` – JSON service account key with deploy permissions
+
 ## License
 
 This project is open source and available under the MIT License.

--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ curl http://localhost:5001/api/v1/executions
 
 All pull requests automatically run the test suite via GitHub Actions. The
 workflow defined in `.github/workflows/test.yml` installs dependencies from
-`requirements.txt` and executes `pytest`.
+`requirements.txt` and also installs `pytest` before executing the tests.
 
 ## Preview Deployments
 


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to run `pytest` on pull requests
- add GitHub Actions workflow to deploy tagged builds to Cloud Run
- document CI and preview deployment in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686ac4347f488320be9564e5f4582a2f