### PR TITLE
Add blocked status

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ An intelligent kanban board application built with Flask, PostgreSQL, and AI age
 ## Features
 
 ### Core Kanban Features
-- **Three-column Kanban Board**: To Do, In Progress, Done
+- **Four-column Kanban Board**: To Do, In Progress, Blocked, Done
 - **Task Management**: Create, edit, delete, and move tasks between columns
 - **Server-driven UI**: All interactions handled server-side with full page refreshes
 - **PostgreSQL Database**: Persistent data storage
@@ -233,8 +233,9 @@ The application provides a RESTful API with the following endpoints:
 
 #### Moving Tasks
 - Use the arrow buttons on each task card to move between columns:
-  - From "To Do" → "In Progress"
-  - From "In Progress" → "To Do" or "Done"
+  - From "To Do" → "In Progress" or "Blocked"
+  - From "In Progress" → "To Do", "Blocked", or "Done"
+  - From "Blocked" → "In Progress"
   - From "Done" → "In Progress"
 
 #### Editing Tasks
@@ -399,7 +400,7 @@ docker-compose run --rm migration python manage_migrations.py upgrade
 - `id`: Primary key (auto-increment)
 - `title`: Task title (required, max 200 characters)
 - `description`: Task description (optional, text)
-- `status`: Task status ('todo', 'in_progress', 'done')
+- `status`: Task status ('todo', 'in_progress', 'blocked', 'done')
 - `created_at`: Creation timestamp
 - `updated_at`: Last update timestamp
 - `assigned_agent_id`: Foreign key to Agent table (optional)

--- a/agent_executor.py
+++ b/agent_executor.py
@@ -88,6 +88,8 @@ class AgentExecutor:
                 # Optionally move task to 'done' status
                 if result.get('task_completed', False):
                     task.status = 'done'
+                if result.get('task_blocked', False):
+                    task.status = 'blocked'
             else:
                 task.execution_status = 'failed'
             
@@ -210,6 +212,18 @@ class AgentExecutor:
                             "iterations": iteration + 1,
                             "total_tokens": total_tokens,
                             "task_completed": True
+                        }
+
+                    # Check if task is blocked
+                    if self._is_task_blocked(response):
+                        return {
+                            "success": True,
+                            "result": "Task marked as blocked",
+                            "conversation": conversation_history,
+                            "iterations": iteration + 1,
+                            "total_tokens": total_tokens,
+                            "task_completed": False,
+                            "task_blocked": True
                         }
                     
                     # Check for explicit stop
@@ -364,6 +378,16 @@ Please analyze the task and create a plan to complete it, then execute that plan
         
         content_lower = content.lower()
         return any(indicator.lower() in content_lower for indicator in completion_indicators)
+
+    def _is_task_blocked(self, response: Dict) -> bool:
+        """Check if the task should be marked as blocked"""
+        from app.core.constants import TASK_BLOCKED_INDICATORS
+        content = response.get('content', '')
+        if not content:
+            return False
+
+        content_lower = content.lower()
+        return any(ind.lower() in content_lower for ind in TASK_BLOCKED_INDICATORS)
     
     def stop_execution(self, execution_id: int) -> Dict[str, Any]:
         """Stop a running execution"""

--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -8,6 +8,7 @@ class TaskStatus(str, Enum):
     """Task status enumeration"""
     TODO = "todo"
     IN_PROGRESS = "in_progress"
+    BLOCKED = "blocked"
     DONE = "done"
 
 
@@ -140,9 +141,17 @@ DB_CONSTRAINTS = {
 TASK_COMPLETION_INDICATORS = [
     "TASK_COMPLETED",
     "task completed",
-    "task is completed", 
+    "task is completed",
     "successfully completed",
     "finished the task"
+]
+
+# Indicators that signify a task is blocked
+TASK_BLOCKED_INDICATORS = [
+    "TASK_BLOCKED",
+    "task blocked",
+    "unable to proceed",
+    "blocked"
 ]
 
 # Dangerous code patterns for script execution

--- a/app/services/task_service.py
+++ b/app/services/task_service.py
@@ -366,9 +366,24 @@ class TaskService:
         """Validate if status transition is allowed"""
         # Define valid transitions
         valid_transitions = {
-            TaskStatus.TODO.value: [TaskStatus.IN_PROGRESS.value, TaskStatus.DONE.value],
-            TaskStatus.IN_PROGRESS.value: [TaskStatus.TODO.value, TaskStatus.DONE.value],
-            TaskStatus.DONE.value: [TaskStatus.TODO.value, TaskStatus.IN_PROGRESS.value]
+            TaskStatus.TODO.value: [
+                TaskStatus.IN_PROGRESS.value,
+                TaskStatus.BLOCKED.value,
+                TaskStatus.DONE.value
+            ],
+            TaskStatus.IN_PROGRESS.value: [
+                TaskStatus.TODO.value,
+                TaskStatus.DONE.value,
+                TaskStatus.BLOCKED.value
+            ],
+            TaskStatus.BLOCKED.value: [
+                TaskStatus.TODO.value,
+                TaskStatus.IN_PROGRESS.value
+            ],
+            TaskStatus.DONE.value: [
+                TaskStatus.TODO.value,
+                TaskStatus.IN_PROGRESS.value
+            ]
         }
         
         return new_status in valid_transitions.get(current_status, [])

--- a/main.py
+++ b/main.py
@@ -41,12 +41,15 @@ def index():
         status='todo').order_by(Task.created_at.desc()).all()
     in_progress_tasks = Task.query.filter_by(
         status='in_progress').order_by(Task.created_at.desc()).all()
+    blocked_tasks = Task.query.filter_by(
+        status='blocked').order_by(Task.created_at.desc()).all()
     done_tasks = Task.query.filter_by(
         status='done').order_by(Task.created_at.desc()).all()
 
     return render_template('index.html',
                            todo_tasks=todo_tasks,
                            in_progress_tasks=in_progress_tasks,
+                           blocked_tasks=blocked_tasks,
                            done_tasks=done_tasks)
 
 
@@ -69,7 +72,7 @@ def add_task():
 
 @app.route('/move_task/<int:task_id>/<status>')
 def move_task(task_id, status):
-    if status not in ['todo', 'in_progress', 'done']:
+    if status not in ['todo', 'in_progress', 'blocked', 'done']:
         flash('Invalid status!', 'error')
         return redirect(url_for('index'))
 

--- a/migrations/versions/6d75a4f9b2b3_add_blocked_status_to_task.py
+++ b/migrations/versions/6d75a4f9b2b3_add_blocked_status_to_task.py
@@ -1,0 +1,31 @@
+"""Add blocked status to task
+
+Revision ID: 6d75a4f9b2b3
+Revises: 8b82368f9352
+Create Date: 2025-07-06 20:52:33.000000
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '6d75a4f9b2b3'
+down_revision = '8b82368f9352'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add check constraint for new blocked status"""
+    op.execute(
+        """
+        ALTER TABLE task
+        ADD CONSTRAINT task_status_check
+        CHECK (status IN ('todo','in_progress','blocked','done'))
+        """
+    )
+
+
+def downgrade():
+    """Remove blocked status constraint"""
+    op.execute("ALTER TABLE task DROP CONSTRAINT IF EXISTS task_status_check")
+

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,7 +11,7 @@
 
 <div class="row">
     <!-- To Do Column -->
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="kanban-column">
             <div class="kanban-header bg-secondary text-white">
                 <h5><i class="fas fa-list"></i> To Do ({{ todo_tasks|length }})</h5>
@@ -79,8 +79,9 @@
         </div>
     </div>
 
+
     <!-- In Progress Column -->
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="kanban-column">
             <div class="kanban-header bg-warning text-dark">
                 <h5><i class="fas fa-clock"></i> In Progress ({{ in_progress_tasks|length }})</h5>
@@ -106,11 +107,15 @@
                         <div class="task-footer">
                             <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
                             <div class="task-move-buttons">
-                                <a href="{{ url_for('move_task', task_id=task.id, status='todo') }}" 
+                                <a href="{{ url_for('move_task', task_id=task.id, status='todo') }}"
                                    class="btn btn-sm btn-secondary">
                                     <i class="fas fa-arrow-left"></i> To Do
                                 </a>
-                                <a href="{{ url_for('move_task', task_id=task.id, status='done') }}" 
+                                <a href="{{ url_for('move_task', task_id=task.id, status='blocked') }}"
+                                   class="btn btn-sm btn-danger">
+                                    <i class="fas fa-ban"></i> Blocked
+                                </a>
+                                <a href="{{ url_for('move_task', task_id=task.id, status='done') }}"
                                    class="btn btn-sm btn-success">
                                     <i class="fas fa-arrow-right"></i> Done
                                 </a>
@@ -121,9 +126,52 @@
             </div>
         </div>
     </div>
+    
+    <!-- Blocked Column -->
+    <div class="col-md-3">
+        <div class="kanban-column">
+            <div class="kanban-header bg-danger text-white">
+                <h5><i class="fas fa-ban"></i> Blocked ({{ blocked_tasks|length }})</h5>
+            </div>
+            <div class="kanban-body">
+                {% for task in blocked_tasks %}
+                    <div class="task-card">
+                        <div class="task-header">
+                            <h6>{{ task.title }}</h6>
+                            <div class="task-actions">
+                                <a href="{{ url_for('edit_task', task_id=task.id) }}" class="btn btn-sm btn-outline-primary">
+                                    <i class="fas fa-edit"></i>
+                                </a>
+                                <a href="{{ url_for('delete_task', task_id=task.id) }}" class="btn btn-sm btn-outline-danger"
+                                   onclick="return confirm('Are you sure you want to delete this task?')">
+                                    <i class="fas fa-trash"></i>
+                                </a>
+                            </div>
+                        </div>
+                        {% if task.description %}
+                            <p class="task-description">{{ task.description }}</p>
+                        {% endif %}
+                        <div class="task-footer">
+                            <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
+                            <div class="task-move-buttons">
+                                <a href="{{ url_for('move_task', task_id=task.id, status='in_progress') }}"
+                                   class="btn btn-sm btn-warning">
+                                    <i class="fas fa-arrow-right"></i> In Progress
+                                </a>
+                                <a href="{{ url_for('move_task', task_id=task.id, status='blocked') }}"
+                                   class="btn btn-sm btn-danger">
+                                    <i class="fas fa-ban"></i> Blocked
+                                </a>
+                            </div>
+                        </div>
+                    </div>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
 
     <!-- Done Column -->
-    <div class="col-md-4">
+    <div class="col-md-3">
         <div class="kanban-column">
             <div class="kanban-header bg-success text-white">
                 <h5><i class="fas fa-check"></i> Done ({{ done_tasks|length }})</h5>


### PR DESCRIPTION
## Summary
- include `blocked` status in the constants
- allow moving tasks to/from Blocked in services, routes, and templates
- show Blocked column on the kanban board
- detect `TASK_BLOCKED` messages in agent executor
- document updated status flows
- add migration for the new status

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'dotenv')*

------
https://chatgpt.com/codex/tasks/task_e_686acc7518b48320bc9855e05be1f1ed