### PR TITLE
Add tool for updating task status

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ An intelligent kanban board application built with Flask, PostgreSQL, and AI age
 - **Multi-LLM Support**: OpenAI GPT, Anthropic Claude, and Google Gemini
 - **Agent Management**: Create, configure, and manage AI agents with custom instructions
 - **Task Assignment**: Assign tasks to AI agents for automated execution
-- **Tool Integration**: Agents can use web search, email, and script execution tools
+- **Tool Integration**: Agents can use web search, email, script execution, and task status update tools
 - **Background Processing**: Asynchronous task execution with Celery and Redis
 - **Execution Monitoring**: Real-time tracking of agent task execution
 - **Conversation Logs**: Detailed logs of agent decision-making processes
@@ -311,6 +311,7 @@ curl http://localhost:5001/api/v1/executions
 1. **Web Search Tool**: Search the web for information using Google Custom Search or DuckDuckGo
 2. **Send Email Tool**: Send emails via SMTP with customizable content
 3. **Execute Script Tool**: Run Python scripts safely with timeout and security restrictions
+4. **Update Task Status Tool**: Move tasks between statuses on the board
 
 #### LLM Providers
 

--- a/agent_executor.py
+++ b/agent_executor.py
@@ -290,6 +290,11 @@ Please analyze the task and create a plan to complete it, then execute that plan
     
     def _get_tools_for_provider(self, tool_names: List[str], provider_name: str) -> List[Dict]:
         """Get tools formatted for the specific LLM provider"""
+        # Ensure task status update tool is always available
+        from app.core.constants import ToolName
+        if ToolName.UPDATE_TASK_STATUS.value not in tool_names:
+            tool_names = list(tool_names) + [ToolName.UPDATE_TASK_STATUS.value]
+
         if provider_name == "openai":
             return tool_registry.get_tools_openai_format(tool_names)
         elif provider_name == "anthropic":

--- a/app/core/constants.py
+++ b/app/core/constants.py
@@ -42,6 +42,7 @@ class ToolName(str, Enum):
     WEB_SEARCH = "web_search"
     SEND_EMAIL = "send_email"
     EXECUTE_SCRIPT = "execute_script"
+    UPDATE_TASK_STATUS = "update_task_status"
 
 
 class APIResponseStatus(str, Enum):

--- a/templates/agents.html
+++ b/templates/agents.html
@@ -107,6 +107,13 @@
                                     <small class="text-muted d-block">Run Python scripts safely</small>
                                 </label>
                             </div>
+                            <div class="form-check">
+                                <input class="form-check-input" type="checkbox" value="update_task_status" id="tool_update_task_status">
+                                <label class="form-check-label" for="tool_update_task_status">
+                                    <i class="fas fa-tasks"></i> Update Task Status
+                                    <small class="text-muted d-block">Change task status</small>
+                                </label>
+                            </div>
                         </div>
                     </div>
                     
@@ -429,6 +436,11 @@ function editAgent(agentId) {
                             <input class="form-check-input" type="checkbox" value="execute_script" id="edit_tool_execute_script"
                                    ${agent.available_tools.includes('execute_script') ? 'checked' : ''}>
                             <label class="form-check-label" for="edit_tool_execute_script">Execute Script</label>
+                        </div>
+                        <div class="form-check">
+                            <input class="form-check-input" type="checkbox" value="update_task_status" id="edit_tool_update_task_status"
+                                   ${agent.available_tools.includes('update_task_status') ? 'checked' : ''}>
+                            <label class="form-check-label" for="edit_tool_update_task_status">Update Task Status</label>
                         </div>
                     </div>
                 </div>

--- a/tests/unit/test_update_task_status_tool.py
+++ b/tests/unit/test_update_task_status_tool.py
@@ -1,0 +1,21 @@
+import pytest
+from app.models.task import Task
+from app.core.constants import TaskStatus
+from tools import UpdateTaskStatusTool
+from db import db
+
+
+def test_update_task_status_tool(db_session, monkeypatch):
+    monkeypatch.setattr(db, "session", db_session)
+
+    task = Task(title="Test Task")
+    db_session.add(task)
+    db_session.commit()
+    db_session.refresh(task)
+
+    tool = UpdateTaskStatusTool()
+    result = tool.execute(task_id=task.id, status=TaskStatus.IN_PROGRESS.value)
+
+    assert result["success"] is True
+    db_session.refresh(task)
+    assert task.status == TaskStatus.IN_PROGRESS.value

--- a/tools.py
+++ b/tools.py
@@ -391,6 +391,60 @@ class ExecuteScriptTool(Tool):
             logger.error(f"Script execution error: {str(e)}")
             return {"success": False, "error": str(e)}
 
+class UpdateTaskStatusTool(Tool):
+    """Tool for updating the status of a task"""
+
+    def __init__(self):
+        from app.services.task_service import TaskService
+        self.task_service = TaskService()
+
+    @property
+    def name(self) -> str:
+        return "update_task_status"
+
+    @property
+    def description(self) -> str:
+        return "Update the status of a task in the kanban board."
+
+    @property
+    def input_schema(self) -> Dict:
+        from app.core.constants import TaskStatus
+        return {
+            "type": "object",
+            "properties": {
+                "task_id": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "ID of the task to update",
+                },
+                "status": {
+                    "type": "string",
+                    "description": "New status for the task",
+                    "enum": [status.value for status in TaskStatus],
+                },
+            },
+            "required": ["task_id", "status"],
+        }
+
+    def execute(self, **kwargs) -> Dict[str, Any]:
+        from app.core.constants import TaskStatus
+        try:
+            task_id = kwargs.get("task_id")
+            status = kwargs.get("status")
+
+            if task_id is None or status is None:
+                return {"success": False, "error": "task_id and status are required"}
+
+            task_id = int(task_id)
+            status_enum = TaskStatus(status)
+
+            task = self.task_service.move_task_to_status(task_id, status_enum)
+            return {"success": True, "result": task.to_dict()}
+
+        except Exception as e:
+            logger.error(f"Task status update error: {str(e)}")
+            return {"success": False, "error": str(e)}
+
 class ToolRegistry:
     """Registry for managing available tools"""
     
@@ -403,6 +457,7 @@ class ToolRegistry:
         self.register_tool(WebSearchTool())
         self.register_tool(SendEmailTool())
         self.register_tool(ExecuteScriptTool())
+        self.register_tool(UpdateTaskStatusTool())
     
     def register_tool(self, tool: Tool):
         """Register a new tool"""


### PR DESCRIPTION
## Summary
- add `UPDATE_TASK_STATUS` tool constant
- implement `UpdateTaskStatusTool` and register in `ToolRegistry`
- ensure every agent can use the new tool
- expose tool selection in agent UI
- document new tool in README
- add unit test for tool execution

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_686f153a58f0832094c3e1eaa68a9e86