### PR TITLE
Add comments for task cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ An intelligent kanban board application built with Flask, PostgreSQL, and AI age
 ### Core Kanban Features
 - **Four-column Kanban Board**: To Do, In Progress, Blocked, Done
 - **Task Management**: Create, edit, delete, and move tasks between columns
+- **Task Comments**: Discuss work directly on each card with inline comments
 - **Server-driven UI**: All interactions handled server-side with full page refreshes
 - **PostgreSQL Database**: Persistent data storage
 - **Docker Support**: Easy deployment and development setup

--- a/app/models/task.py
+++ b/app/models/task.py
@@ -22,6 +22,8 @@ class Task(Base):
     id = Column(Integer, primary_key=True)
     title = Column(String(200), nullable=False)
     description = Column(Text)
+    # List of comments associated with the task
+    comments = Column(JSON, default=list)
     status = Column(String(20), nullable=False, default=TaskStatus.TODO.value)
     created_at = Column(DateTime, default=utcnow)
     updated_at = Column(DateTime, default=utcnow, onupdate=utcnow)
@@ -43,6 +45,7 @@ class Task(Base):
             'id': self.id,
             'title': self.title,
             'description': self.description,
+            'comments': self.comments or [],
             'status': self.status,
             'execution_status': self.execution_status,
             'created_at': self.created_at.isoformat() if self.created_at else None,
@@ -62,6 +65,7 @@ class Task(Base):
         return cls(
             title=data['title'],
             description=data.get('description'),
+            comments=data.get('comments', []),
             status=data.get('status', TaskStatus.TODO.value),
             assigned_agent_id=data.get('assigned_agent_id'),
             execution_status=data.get('execution_status', ExecutionStatus.MANUAL.value)
@@ -73,6 +77,8 @@ class Task(Base):
             self.title = data['title']
         if 'description' in data:
             self.description = data['description']
+        if 'comments' in data:
+            self.comments = data['comments']
         if 'status' in data:
             self.status = data['status']
         if 'assigned_agent_id' in data:

--- a/main.py
+++ b/main.py
@@ -154,6 +154,24 @@ def edit_task(task_id):
 
     return render_template('edit_task.html', task=task)
 
+
+@app.route('/add_comment/<int:task_id>', methods=['POST'])
+@login_required
+def add_comment(task_id):
+    """Add a comment to a task"""
+    task = Task.query.get_or_404(task_id)
+    comment = request.form.get('comment')
+    if comment:
+        comments = task.comments or []
+        comments.append(comment)
+        task.comments = comments
+        task.updated_at = datetime.utcnow()
+        db.session.commit()
+        flash('Comment added', 'success')
+    else:
+        flash('Comment cannot be empty', 'error')
+    return redirect(url_for('index'))
+
 # UI Routes for Agent Management
 
 

--- a/migrations/versions/add_task_comments.py
+++ b/migrations/versions/add_task_comments.py
@@ -1,0 +1,28 @@
+"""Add comments column to task
+
+Revision ID: add_task_comments
+Revises: 5a6c245589e6
+Create Date: 2025-07-10 02:00:00.000000
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = 'add_task_comments'
+down_revision = '5a6c245589e6'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Add comments JSON column"""
+    op.add_column('task', sa.Column('comments', postgresql.JSON(), nullable=True))
+    op.execute("UPDATE task SET comments = '[]' WHERE comments IS NULL")
+
+
+def downgrade():
+    """Remove comments column"""
+    op.drop_column('task', 'comments')
+

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -27,6 +27,7 @@ body {
     overflow-y: auto;
 }
 
+/* Task Card Styles: visual layout for each task on the board */
 .task-card {
     background-color: #ffffff;
     border: 1px solid #e9ecef;
@@ -51,6 +52,7 @@ body {
     box-shadow: 0 4px 12px rgba(0,0,0,0.2);
 }
 
+/* Header section of a task card containing title and actions */
 .task-header {
     display: flex;
     justify-content: space-between;
@@ -66,11 +68,13 @@ body {
     margin-right: 10px;
 }
 
+/* Action buttons shown when hovering over a task card */
 .task-actions {
     display: flex;
     gap: 5px;
 }
 
+/* Optional description text within a task card */
 .task-description {
     color: #666;
     font-size: 0.9em;
@@ -78,6 +82,31 @@ body {
     line-height: 1.4;
 }
 
+/* List of comments displayed on a task card */
+.task-comments {
+    list-style: none;
+    padding-left: 0;
+    margin-bottom: 8px;
+    font-size: 0.85em;
+    color: #444;
+}
+
+.task-comments li {
+    margin-bottom: 2px;
+}
+
+/* Form for adding comments on a task card */
+.comment-form .form-control {
+    font-size: 0.8em;
+    padding: 2px 6px;
+}
+
+.comment-form .btn {
+    font-size: 0.8em;
+    padding: 2px 8px;
+}
+
+/* Footer section showing dates and movement buttons */
 .task-footer {
     display: flex;
     justify-content: space-between;
@@ -87,6 +116,7 @@ body {
     border-top: 1px solid #e9ecef;
 }
 
+/* Buttons used to move tasks between columns */
 .task-move-buttons {
     display: flex;
     gap: 5px;

--- a/templates/index.html
+++ b/templates/index.html
@@ -18,6 +18,7 @@
             </div>
             <div class="kanban-body">
                 {% for task in todo_tasks %}
+                    <!-- Task card: displays a single task in the To Do column -->
                     <div class="task-card clickable-card" data-task-id="{{ task.id }}" onclick="showTaskDetails({{ task.id }})">
                         <div class="task-header">
                             <h6>{{ task.title }}</h6>
@@ -37,6 +38,19 @@
                         {% if task.description %}
                             <p class="task-description">{{ task.description }}</p>
                         {% endif %}
+                        {% if task.comments %}
+                            <ul class="task-comments">
+                                {% for comment in task.comments %}
+                                    <li>{{ comment }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        <form action="{{ url_for('add_comment', task_id=task.id) }}" method="post" class="comment-form">
+                            <div class="input-group input-group-sm mb-2">
+                                <input type="text" class="form-control" name="comment" placeholder="Add comment" required>
+                                <button class="btn btn-outline-secondary" type="submit">Post</button>
+                            </div>
+                        </form>
                         
                         <!-- Agent Assignment Info -->
                         {% if task.assigned_agent %}
@@ -88,6 +102,7 @@
             </div>
             <div class="kanban-body">
                 {% for task in in_progress_tasks %}
+                    <!-- Task card: displays a single task in the In Progress column -->
                     <div class="task-card clickable-card" data-task-id="{{ task.id }}" onclick="showTaskDetails({{ task.id }})">
                         <div class="task-header">
                             <h6>{{ task.title }}</h6>
@@ -104,6 +119,19 @@
                         {% if task.description %}
                             <p class="task-description">{{ task.description }}</p>
                         {% endif %}
+                        {% if task.comments %}
+                            <ul class="task-comments">
+                                {% for comment in task.comments %}
+                                    <li>{{ comment }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        <form action="{{ url_for('add_comment', task_id=task.id) }}" method="post" class="comment-form">
+                            <div class="input-group input-group-sm mb-2">
+                                <input type="text" class="form-control" name="comment" placeholder="Add comment" required>
+                                <button class="btn btn-outline-secondary" type="submit">Post</button>
+                            </div>
+                        </form>
                         <div class="task-footer">
                             <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
                             <div class="task-move-buttons">
@@ -135,6 +163,7 @@
             </div>
             <div class="kanban-body">
                 {% for task in blocked_tasks %}
+                    <!-- Task card: displays a single task in the Blocked column -->
                     <div class="task-card">
                         <div class="task-header">
                             <h6>{{ task.title }}</h6>
@@ -151,6 +180,19 @@
                         {% if task.description %}
                             <p class="task-description">{{ task.description }}</p>
                         {% endif %}
+                        {% if task.comments %}
+                            <ul class="task-comments">
+                                {% for comment in task.comments %}
+                                    <li>{{ comment }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        <form action="{{ url_for('add_comment', task_id=task.id) }}" method="post" class="comment-form">
+                            <div class="input-group input-group-sm mb-2">
+                                <input type="text" class="form-control" name="comment" placeholder="Add comment" required>
+                                <button class="btn btn-outline-secondary" type="submit">Post</button>
+                            </div>
+                        </form>
                         <div class="task-footer">
                             <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
                             <div class="task-move-buttons">
@@ -178,6 +220,7 @@
             </div>
             <div class="kanban-body">
                 {% for task in done_tasks %}
+                    <!-- Task card: displays a single task in the Done column -->
                     <div class="task-card clickable-card" data-task-id="{{ task.id }}" onclick="showTaskDetails({{ task.id }})">
                         <div class="task-header">
                             <h6>{{ task.title }}</h6>
@@ -194,6 +237,19 @@
                         {% if task.description %}
                             <p class="task-description">{{ task.description }}</p>
                         {% endif %}
+                        {% if task.comments %}
+                            <ul class="task-comments">
+                                {% for comment in task.comments %}
+                                    <li>{{ comment }}</li>
+                                {% endfor %}
+                            </ul>
+                        {% endif %}
+                        <form action="{{ url_for('add_comment', task_id=task.id) }}" method="post" class="comment-form">
+                            <div class="input-group input-group-sm mb-2">
+                                <input type="text" class="form-control" name="comment" placeholder="Add comment" required>
+                                <button class="btn btn-outline-secondary" type="submit">Post</button>
+                            </div>
+                        </form>
                         <div class="task-footer">
                             <small class="text-muted">{{ task.created_at.strftime('%Y-%m-%d %H:%M') }}</small>
                             <div class="task-move-buttons">


### PR DESCRIPTION
## Summary
- add comments column to Task model
- allow posting comments from the board UI
- display comment lists and input forms in task cards
- style comments section in CSS
- document new feature in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*


------
https://chatgpt.com/codex/tasks/task_e_686f1962ed9c832082a89de6eb6090a1